### PR TITLE
made the image dialog modal

### DIFF
--- a/src/window/ImageDialog.vala
+++ b/src/window/ImageDialog.vala
@@ -84,7 +84,7 @@ class ImageDialog : Gtk.Window {
     file_dialog.set_current_name(filename);
     file_dialog.set_transient_for (this);
 
-
+    this.set_modal(true);
     this.set_transient_for(parent);
   }
 


### PR DESCRIPTION
When you click on an image shown inline in the timeline, corebird shows up a nice preview of that image. Clicking on the image, or pressing escape removes the preview. However, if you click elsewhere on the corebird screen, the image does not disappear. Furthermore if where you happened to click was a link on the timeline, the main corebird window follows that link and the image stays overlaid the main window.

To fix this issue, this merge suggests that the image dialog window be made modal, so clicking anywhere on or off the image closes the image.
