### PR TITLE
made the text of the DM wrap

### DIFF
--- a/ui/dm-list-entry.ui
+++ b/ui/dm-list-entry.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.0 on Thu Oct 31 21:58:15 2013 -->
+<!-- Generated with glade 3.16.0 on Sun Nov 10 10:45:42 2013 -->
 <interface>
   <!-- interface-requires gtk+ 3.10 -->
   <template class="DMListEntry" parent="GtkListBoxRow">
@@ -100,6 +100,7 @@
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
                 <property name="label">TEXT!</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
A quick glade file fix to make the text of a DM wrap, to avoid horizontal scrolling:
# Before the patch:

![wrap-before](https://f.cloud.github.com/assets/592259/1508862/ffde8034-4a1f-11e3-867b-9259b7a3eafc.png)
# After the patch

![after-wrap](https://f.cloud.github.com/assets/592259/1508863/fffff25a-4a1f-11e3-9d2d-247a3ff21b37.png)
