### PR TITLE
added an appdata file for corebird.

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,5 +1,6 @@
 install (FILES corebird.desktop            DESTINATION ${PREFIX}/share/applications/)
 install (FILES fontawesome-webfont.ttf     DESTINATION ${PREFIX}/share/fonts/TTF/)
+install (FILES corebird.appdata.xml        DESTINATION ${PREFIX}/share/appdata/)
 
 if (CATALOG)
   install (FILES corebird-catalog.xml DESTINATION ${PREFIX}/share/glade/catalogs/)

--- a/data/corebird.appdata.xml
+++ b/data/corebird.appdata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2013 Ryan Lerch <ryanlerch@fedoraproject.org> -->
+<application>
+ <id type="desktop">corebird.desktop</id>
+ <licence>CC0</licence>
+ <description>
+  <p>
+   Corebird is a native GTK+ twitter client that provides vital features such as Direct Messages (DMs), tweet notifications, conversation views.
+  </p>
+  <p>
+   Additional features include the abilty to change to the GTK+ dark theme, searching and media uploads.
+  </p>
+ </description>
+ <url type="homepage">http://corebird.baedert.org/</url>
+ <screenshots>
+  <screenshot type="default" width="800" height="450">http://ryanlerch.org/corebird/corebird.png</screenshot>
+  <screenshot width="800" height="450">http://ryanlerch.org/corebird/corebird2.png</screenshot>
+  <screenshot width="800" height="450">http://ryanlerch.org/corebird/corebird3.png</screenshot>
+ </screenshots>
+ <updatecontact>ryanlerch@fedoraproject.org</updatecontact>
+</application>


### PR DESCRIPTION
Added an [Appdata](http://people.freedesktop.org/~hughsient/appdata/) file for corebird.

Please check that i have also added the right stuff for cmake (wasnt 100% sure what to do here.)

these files are used by the new [gnome-software](https://git.gnome.org/browse/gnome-software/) application. Note that the screenshot in appdata require an external link, so i am currently hosting them on my webserver, but can move them over to the official corebird site if needed.

Also, appdata requires a scecific aspect ratio for the screenshots, so i couldnt just use the ones already corebird site. :(

The screenshots are:

![corebird](http://ryanlerch.org/corebird/corebird.png)
![corebird](http://ryanlerch.org/corebird/corebird2.png)
![corebird](http://ryanlerch.org/corebird/corebird3.png)
