### PR TITLE
Remove obsolete Category from desktop file

### DIFF
--- a/data/corebird.desktop
+++ b/data/corebird.desktop
@@ -1,7 +1,6 @@
-
 [Desktop Entry]
 Name=Corebird
 Exec=corebird
 Type=Application
 Icon=corebird
-Categories=Network;Application;
+Categories=Network;GNOME;


### PR DESCRIPTION
"Application" keyword is deprecated.
GNOME was added because it relies on GNOME libraries
