### PR TITLE
Added wrapping <span> elements to links in gtk labels

### DIFF
--- a/src/ProfilePage.vala
+++ b/src/ProfilePage.vala
@@ -427,7 +427,7 @@ class ProfilePage : ScrollWidget, IPage {
 
     if (url != null && url != "") {
       url_label.visible = true;
-      url_label.set_markup ("<a href='%s'>%s</a>".printf (url, url));
+      url_label.set_markup ("<span underline='none'><a href='%s'>%s</a></span>".printf (url, url));
     } else
       url_label.visible = false;
 

--- a/src/TweetInfoPage.vala
+++ b/src/TweetInfoPage.vala
@@ -421,7 +421,7 @@ class TweetInfoPage : IPage , ScrollWidget {
   private void set_source_link (int64 id, string screen_name) {
     var link = "https://twitter.com/%s/status/%s".printf (screen_name,
                                                           id.to_string());
-    source_label.label = "<a href='%s' title='Open in Browser'>Source</a>".printf (link);
+    source_label.label = "<span underline='none'><a href='%s' title='Open in Browser'>Source</a></span>".printf (link);
   }
 
   /**

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -86,8 +86,8 @@ class TweetListEntry : ITwitterItem, ListBoxRow {
     update_time_delta ();
     if (tweet.is_retweet) {
       rt_box.show ();
-      rt_label.label = @"<a href=\"@$(tweet.rt_by_id)\"
-                         title=\"@$(tweet.rt_by_screen_name)\">$(tweet.retweeted_by)</a>";
+      rt_label.label = @"<span underline='none'><a href=\"@$(tweet.rt_by_id)\"
+                         title=\"@$(tweet.rt_by_screen_name)\">$(tweet.retweeted_by)</a></span>";
     } else
       rt_box.unparent ();
 

--- a/src/util/TweetUtils.vala
+++ b/src/util/TweetUtils.vala
@@ -59,7 +59,7 @@ namespace TweetUtils {
         title = html_url;
 
       formatted_text = formatted_text.splice (from, to,
-           "<a href=\"%s\" title=\"%s\">%s</a>".printf(html_url,
+           "<span underline='none'><a href=\"%s\" title=\"%s\">%s</a></span>".printf(html_url,
                                                        title,
                                                        s.display_url.replace ("&", "&amp;")));
       char_diff += formatted_text.char_count () - length_before;


### PR DESCRIPTION
Added wrapping <span> elements with the attribute "underline='none'" around links in GTKLabel to remove the underline in links in GTK labels.

solves issue #113 
