### PR TITLE
Correct dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
  - `json-glib-1.0`
  - `libnotify`
  - `sqlite3`
- - `libsoup-2.4`
+ - `libsoup >= 2.42`
  - `libgee-0.8`
  - `vala >= 0.22` (makedep)
  - `cmake >= 2.6` (makedep)


### PR DESCRIPTION
Found out from Lyude1337/lyude-overlay#1 that corebird needs libgee-0.8 to build, and that it won't build correctly with anything older then libsoup 2.42. Not having libgee installed when trying to build corebird results in cmake throwing up an error, and trying to compile with older versions of libsoup (I tried with 2.40.3) results in a linker error.
