### PR TITLE
Correct tweet length calculation.

### DIFF
--- a/src/util/TweetUtils.vala
+++ b/src/util/TweetUtils.vala
@@ -284,7 +284,7 @@ namespace TweetUtils {
         return Twitter.short_url_length; // Default to HTTP
     }
 
-    return s.length;
+    return s.char_count();
   }
 
   bool activate_link (string uri, MainWindow window) {


### PR DESCRIPTION
Since vala 0.11, string.length does not return number of unicode character pointers. To calculate length of tweet using vala 0.11, we have to use string.char_count().
