### PR TITLE
A better user info page

### DIFF
--- a/src/ProfilePage.vala
+++ b/src/ProfilePage.vala
@@ -466,9 +466,9 @@ class ProfilePage : ScrollWidget, IPage {
       desc = TweetUtils.get_formatted_text (description, text_urls);
     }
     description_label.label = "<big>" + desc + "</big>";
-    tweets_label.label = tweets.to_string();
-    followers_label.label = followers.to_string();
-    following_label.label = following.to_string();
+    tweets_label.label = "%'d".printf(tweets);
+    followers_label.label = "%'d".printf(followers);
+    following_label.label = "%'d".printf(following);
 
     if (location != null && location != "") {
       location_label.visible = true;

--- a/ui/profile-page.ui
+++ b/ui/profile-page.ui
@@ -66,7 +66,7 @@
               <object class="AspectImage" id="banner_image">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="scale">0.30000001192092896</property>
+                <property name="scale">0.3</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -356,7 +356,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">--</property>
+                    <property name="label">--</property>
                     <property name="justify">center</property>
                   </object>
                   <packing>
@@ -385,7 +385,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">--</property>
+                    <property name="label">--</property>
                     <property name="justify">center</property>
                   </object>
                   <packing>
@@ -414,7 +414,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">--</property>
+                    <property name="label">--</property>
                     <property name="justify">center</property>
                   </object>
                   <packing>


### PR DESCRIPTION
A better user information page with a slightly ameliorated layout. It now shows how much tweets, followers and followings a user have.

_PS: this is my first github contribution ever, so tell me if I am proceeding the wrong way._

![userinfo](https://cloud.githubusercontent.com/assets/6125772/3291608/f525a322-f585-11e3-9853-a81a87e6920c.png)
