### PR TITLE
Fix man page installation directory

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -11,8 +11,7 @@ appdata_in_files = corebird.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 @INTLTOOL_XML_RULE@
 
-manpagedir = $(mandir)
-manpage_DATA = corebird.1
+man_MANS = corebird.1
 
 if ENABLE_CATALOG
   catalogdir = $(prefix)/share/glade/catalogs/


### PR DESCRIPTION
Use the right automake invocation to make the man page properly go to
/usr/share/man/man1.
