### PR TITLE
Use vaapisink instead of xvimagesink for videos

### DIFF
--- a/src/window/VideoDialog.vala
+++ b/src/window/VideoDialog.vala
@@ -39,7 +39,7 @@ class VideoDialog : Gtk.Window {
     drawing_area.realize.connect (realize_cb);
 #if VIDEO
     this.src  = Gst.ElementFactory.make ("playbin", "video");
-    this.sink = Gst.ElementFactory.make ("xvimagesink", "sink");
+    this.sink = Gst.ElementFactory.make ("vaapisink", "sink");
     this.src.set ("video-sink", sink, null);
     var bus = src.get_bus ();
     bus.set_sync_handler (bus_sync_handler);


### PR DESCRIPTION
On my setup corebird crashes with this backtrace when trying to watch an
embedded video for a tweet:

0 0x000000302f82f8e0 in video_orc_unpack_NV12 () from
/lib64/libgstvideo-1.0.so.0
1 0x000000302f81276f in unpack_NV12 () from /lib64/libgstvideo-1.0.so.0
2 0x00007fffe7bedb17 in videoconvert_convert_generic () from
/usr/lib64/gstreamer-1.0/libgstvideoconvert.so
3 0x00007fffe7bec83e in gst_video_convert_transform_frame () from
/usr/lib64/gstreamer-1.0/libgstvideoconvert.so
4 0x000000302f818d9e in gst_video_filter_transform () from
/lib64/libgstvideo-1.0.so.0
5 0x000000302ec3597e in gst_base_transform_handle_buffer () from
/lib64/libgstbase-1.0.so.0
6 0x000000302ec361c5 in gst_base_transform_chain () from
/lib64/libgstbase-1.0.so.0
7 0x00000030278654e6 in gst_pad_push_data () from
/lib64/libgstreamer-1.0.so.0
8 0x000000302ec363d6 in gst_base_transform_chain () from
/lib64/libgstbase-1.0.so.0
9 0x00000030278654e6 in gst_pad_push_data () from
/lib64/libgstreamer-1.0.so.0
10 0x000000302785718b in gst_proxy_pad_chain_default () from
/lib64/libgstreamer-1.0.so.0
11 0x00000030278654e6 in gst_pad_push_data () from
/lib64/libgstreamer-1.0.so.0
12 0x00007fffec11704f in gst_queue_loop () from
/usr/lib64/gstreamer-1.0/libgstcoreelements.so
13 0x0000003027893f09 in gst_task_func () from
/lib64/libgstreamer-1.0.so.0
14 0x0000003003872496 in g_thread_pool_thread_proxy () from
/lib64/libglib-2.0.so.0
15 0x0000003003871abd in g_thread_proxy () from /lib64/libglib-2.0.so.0
16 0x0000003001c08141 in start_thread () from /lib64/libpthread.so.0
17 0x00000030018ec65d in clone () from /lib64/libc.so.6

From the logs it looks like it's using the VAAPI plugin which apparently
doesn't play well with xvimagesink[1][2]. Switching to vaapisink fixes
the video playback for me.

[1] https://bugs.tizen.org/jira/si/jira.issueviews:issue-html/PTREL-792/PTREL-792.html
[2] https://bugs.tizen.org/jira/browse/TIVI-437
