### PR TITLE
A11y: Accessibility label for BadgeRadioToolButton widget

### DIFF
--- a/src/DMThreadsPage.vala
+++ b/src/DMThreadsPage.vala
@@ -369,8 +369,7 @@ class DMThreadsPage : IPage, IMessageReceiver, ScrollWidget {
   }
 
   public void create_tool_button(Gtk.RadioButton? group) {
-    tool_button = new BadgeRadioToolButton(group, "mail-unread-symbolic");
-    tool_button.tooltip_text = _("Direct Messages");
+    tool_button = new BadgeRadioToolButton(group, "mail-unread-symbolic", _("Direct Messages"));
   }
 
   public Gtk.RadioButton? get_tool_button() {

--- a/src/FavoritesTimeline.vala
+++ b/src/FavoritesTimeline.vala
@@ -72,7 +72,6 @@ class FavoritesTimeline : IMessageReceiver, DefaultTimeline {
   }
 
   public override void create_tool_button (Gtk.RadioButton? group) {
-    tool_button = new BadgeRadioToolButton(group, "starred-symbolic");
-    tool_button.tooltip_text = _("Favorites");
+    tool_button = new BadgeRadioToolButton(group, "starred-symbolic", _("Favorites"));
   }
 }

--- a/src/FilterPage.vala
+++ b/src/FilterPage.vala
@@ -209,9 +209,9 @@ class FilterPage : Gtk.ScrolledWindow, IPage, IMessageReceiver {
 
   public void on_leave () {}
   public void create_tool_button (Gtk.RadioButton? group) {
-    tool_button = new BadgeRadioToolButton(group, "corebird-filter-symbolic");
-    tool_button.tooltip_text = _("Filters");
+    tool_button = new BadgeRadioToolButton(group, "corebird-filter-symbolic", _("Filters"));
   }
+
   public Gtk.RadioButton? get_tool_button() { return tool_button; }
 
   public string? get_title () {

--- a/src/HomeTimeline.vala
+++ b/src/HomeTimeline.vala
@@ -131,7 +131,6 @@ public class HomeTimeline : IMessageReceiver, DefaultTimeline {
   }
 
   public override void create_tool_button (Gtk.RadioButton? group) {
-    tool_button = new BadgeRadioToolButton(group, "user-home-symbolic");
-    tool_button.tooltip_text = _("Home");
+    tool_button = new BadgeRadioToolButton(group, "user-home-symbolic", _("Home"));
   }
 }

--- a/src/ListsPage.vala
+++ b/src/ListsPage.vala
@@ -124,8 +124,7 @@ class ListsPage : IPage, ScrollWidget, IMessageReceiver {
 
 
   public void create_tool_button (Gtk.RadioButton? group) {
-    tool_button = new BadgeRadioToolButton (group, "view-list-symbolic");
-    tool_button.tooltip_text = _("Lists");
+    tool_button = new BadgeRadioToolButton (group, "view-list-symbolic", _("Lists"));
   }
 
 

--- a/src/MentionsTimeline.vala
+++ b/src/MentionsTimeline.vala
@@ -125,8 +125,7 @@ class MentionsTimeline : IMessageReceiver, DefaultTimeline {
 
 
   public override void create_tool_button (Gtk.RadioButton? group) {
-    tool_button = new BadgeRadioToolButton(group, "corebird-mentions-symbolic");
-    tool_button.tooltip_text = _("Mentions");
+    tool_button = new BadgeRadioToolButton(group, "corebird-mentions-symbolic", _("Mentions"));
   }
 
 }

--- a/src/SearchPage.vala
+++ b/src/SearchPage.vala
@@ -254,8 +254,7 @@ class SearchPage : IPage, Gtk.Box {
   } // }}}
 
   public void create_tool_button (Gtk.RadioButton? group){
-    tool_button = new BadgeRadioToolButton (group, "edit-find-symbolic");
-    tool_button.tooltip_text = _("Search");
+    tool_button = new BadgeRadioToolButton (group, "edit-find-symbolic", _("Search"));
   }
 
   public Gtk.RadioButton? get_tool_button() {

--- a/src/widgets/BadgeRadioToolButton.vala
+++ b/src/widgets/BadgeRadioToolButton.vala
@@ -20,12 +20,18 @@ public class BadgeRadioToolButton : Gtk.RadioButton {
   private static const int BADGE_SIZE = 10;
   public bool show_badge{ get; set; default = false;}
 
-  public BadgeRadioToolButton (Gtk.RadioButton group, string icon_name) {
+  public BadgeRadioToolButton (Gtk.RadioButton group, string icon_name, string text="") {
     GLib.Object (group: group);
     this.get_style_context ().add_class ("image-button");
     var i = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.BUTTON);
     this.add (i);
     this.set_mode (false);
+
+    if(text != "") {
+      this.tooltip_text = text;
+      Atk.Object accessible = this.get_accessible();
+      accessible.set_name(text);
+    }
   }
 
   public override bool draw (Cairo.Context c){


### PR DESCRIPTION
After the latest widgets related refactor badge radio buttons on the main window sidebar no longer have accessible name present. This is noticeable by the people relying on assistive tools such as orca screen reader.
For default GTK widgets tooltip text is used also as an accessible name however after creating own custom subclasses this no longer appears to be the case so I have tried to add it.
