### PR TITLE
Install the gsettings schema in the corebird prefix and load it up.

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -11,6 +11,9 @@ appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 
 man_MANS = corebird.1
 
+# if you change this, change Config.vala.in too.
+# This overrided what configure defines.
+gsettingsschemadir = $(prefix)/share/corebird/schemas/
 gsettings_SCHEMAS = org.baedert.corebird.gschema.xml
 @INTLTOOL_XML_NOMERGE_RULE@
 @GSETTINGS_RULES@

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -20,7 +20,10 @@ public class Settings : GLib.Object {
   private static GLib.Settings settings;
 
   public static void init(){
-    settings = new GLib.Settings("org.baedert.corebird");
+    SettingsSchemaSource sss = new SettingsSchemaSource.from_directory(
+      GSETTINGSDIR, null, false);
+    SettingsSchema schema = sss.lookup("org.baedert.corebird", false);
+    settings = new GLib.Settings.full(schema, null, null);
   }
 
   public static new GLib.Settings get () {

--- a/src/util/Config.vala.in
+++ b/src/util/Config.vala.in
@@ -19,3 +19,4 @@
 public const string DATADIR = "@prefix@/share/corebird/";
 public const string LOCALEDIR = "@prefix@/share/locale";
 public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+public const string GSETTINGSDIR = "@prefix@/share/corebird/schemas/";


### PR DESCRIPTION
Because that's the only non broken way to use GSettings.
