### PR TITLE
(feat) added spell check for tweet compose text box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This is the readme for the current *development version*. If you're looking for 
  - `libsoup-2.4`
  - `intltool >= 0.40`
  - `libgee-0.8`
+ - `gtkspell3-3.0`
  - `vala >= 0.26` (makedep)
  - `automake >= 1.14` (makedep)
  - `gstreamer-1.0` (disable via --disable-video, default enabled)

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ This is the readme for the current *development version*. If you're looking for 
  - `libsoup-2.4`
  - `intltool >= 0.40`
  - `libgee-0.8`
- - `gtkspell3-3.0`
  - `vala >= 0.26` (makedep)
  - `automake >= 1.14` (makedep)
  - `gstreamer-1.0` (disable via --disable-video, default enabled)
  - `gst-plugins-bad-1.0` (disable via --disable-video, default enabled)
  - `gst-plugins-good-1.0` (disable via --disable-video, default enabled)
  - `gst-libav-1.0` (disable via --disable-video, default enabled)
+ - `gtkspell3-3.0` (disable via --disable-spell-check, default enabled)
 
 Note that the above packages are just rough estimations, the actual package names on your distribution may vary.
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,8 @@ pkg_modules="gtk+-3.0 >= 3.14
              libsoup-2.4
              gee-0.8
              json-glib-1.0
-             sqlite3"
+             sqlite3
+             gtkspell3-3.0"
 
 if test "$disable_video" = "no"; then
   pkg_modules="$pkg_modules gstreamer-video-1.0 gdk-x11-3.0"
@@ -53,6 +54,7 @@ CB_VALA_FLAGS=" \
   --pkg sqlite3 \
   --pkg libsoup-2.4 \
   --pkg glib-2.0 \
+  --pkg gtkspell3-3.0 \
   --target-glib=2.38 \
   --gresources=\$(top_srcdir)/resources.xml \
   --vapidir=\$(top_srcdir)/vapi/ \

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,9 @@ AM_CONDITIONAL([ENABLE_DEBUG], [ test "$enable_debug" = "yes"])
 AC_ARG_ENABLE(video, AS_HELP_STRING([--disable-video], [Disable video support]),, disable_video=no)
 AM_CONDITIONAL([DISABLE_VIDEO], [ test "$disable_video" = "yes"])
 
-
+# --disable-spell-check
+AC_ARG_ENABLE(spell_check, AS_HELP_STRING([--disable-spell-check], [Disable spell check]),, disable_spell_check=no)
+AM_CONDITIONAL([DISABLE_SPELL_CHECK], [ test "$disable_spell_check" = "yes"])
 
 
 # Vala Packages {{{
@@ -36,11 +38,14 @@ pkg_modules="gtk+-3.0 >= 3.14
              libsoup-2.4
              gee-0.8
              json-glib-1.0
-             sqlite3
-             gtkspell3-3.0"
+             sqlite3"
 
 if test "$disable_video" = "no"; then
   pkg_modules="$pkg_modules gstreamer-video-1.0 gdk-x11-3.0"
+fi
+
+if test "$disable_spell_check" = "no"; then
+  pkg_modules="$pkg_modules gtkspell3-3.0"
 fi
 
 PKG_CHECK_MODULES(CB, [$pkg_modules])
@@ -54,7 +59,6 @@ CB_VALA_FLAGS=" \
   --pkg sqlite3 \
   --pkg libsoup-2.4 \
   --pkg glib-2.0 \
-  --pkg gtkspell3-3.0 \
   --target-glib=2.38 \
   --gresources=\$(top_srcdir)/resources.xml \
   --vapidir=\$(top_srcdir)/vapi/ \
@@ -81,6 +85,12 @@ if test "$disable_video" = "no"; then
                  -D VIDEO \
                  --pkg gstreamer-video-1.0 \
                  --pkg gdk-x11-3.0"
+fi
+
+if test "$disable_spell_check" = "no"; then
+  CB_VALA_FLAGS="$CB_VALA_FLAGS \
+                 -D SPELL_CHECK \
+                 --pkg gtkspell3-3.0"
 fi
 
 if test "$enable_debug" = "yes"; then

--- a/src/widgets/CompletionTextView.vala
+++ b/src/widgets/CompletionTextView.vala
@@ -20,7 +20,6 @@ class CompletionTextView : Gtk.TextView {
   private Gtk.Window completion_window;
   private int current_match = 0;
 
-
   private unowned Account account;
 
   construct {
@@ -53,6 +52,19 @@ class CompletionTextView : Gtk.TextView {
     this.buffer.notify["cursor-position"].connect (update_completion);
     this.buffer.changed.connect (buffer_changed_cb);
     this.key_press_event.connect (key_press_event_cb);
+
+    var spell_checker = new GtkSpell.Checker ();
+    spell_checker.attach (this);
+    spell_checker.language_changed.connect (() => {
+      var lang = spell_checker.get_language ();
+      if (lang != null) {
+        try {
+          spell_checker.set_language (lang);
+        } catch {
+          debug ("Failed to set spell checker language: %s", lang);
+        }
+      }
+    });
   }
 
   public void set_account (Account account) {

--- a/src/widgets/CompletionTextView.vala
+++ b/src/widgets/CompletionTextView.vala
@@ -53,6 +53,7 @@ class CompletionTextView : Gtk.TextView {
     this.buffer.changed.connect (buffer_changed_cb);
     this.key_press_event.connect (key_press_event_cb);
 
+#if SPELL_CHECK
     var spell_checker = new GtkSpell.Checker ();
     spell_checker.attach (this);
     spell_checker.language_changed.connect (() => {
@@ -65,6 +66,7 @@ class CompletionTextView : Gtk.TextView {
         }
       }
     });
+#endif    
   }
 
   public void set_account (Account account) {


### PR DESCRIPTION
This patch added spell check support for tweet composer to address #283 

I have added gtkspell3 as a dependency.