### PR TITLE
bugfix: applying text.index_of_nth_char too many times

### DIFF
--- a/src/util/TextTransform.vala
+++ b/src/util/TextTransform.vala
@@ -85,7 +85,7 @@ namespace TextTransform {
 
       if (entities[i].to == cur_end) {
         entities[i].info |= TRAILING;
-        cur_end = text.index_of_nth_char (entities[i].from);
+        cur_end = entities[i].from;
       } else break;
     }
 


### PR DESCRIPTION
Applying text.index_of_nth_char would cause the cur_end index to 'desync' on certain japanese text with entities at the end. It woudl cause the next substring call to crash on some inputs (due to invalid indices).

I noticed this bug when trying to search for "倉庫番" in corebird. This edit stopped the crash and allows me to search that term.