### PR TITLE
Automake: Use datarootdir instead of prefix/share

### DIFF
--- a/assets/128x128/Makefile.am
+++ b/assets/128x128/Makefile.am
@@ -1,2 +1,2 @@
-icondir = $(prefix)/share/icons/hicolor/128x128/apps/
+icondir = $(datarootdir)/icons/hicolor/128x128/apps/
 dist_icon_DATA = corebird.png

--- a/assets/16x16/Makefile.am
+++ b/assets/16x16/Makefile.am
@@ -1,2 +1,2 @@
-icondir = $(prefix)/share/icons/hicolor/16x16/apps/
+icondir = $(datarootdir)/icons/hicolor/16x16/apps/
 dist_icon_DATA = corebird.png

--- a/assets/24x24/Makefile.am
+++ b/assets/24x24/Makefile.am
@@ -1,2 +1,2 @@
-icondir = $(prefix)/share/icons/hicolor/24x24/apps/
+icondir = $(datarootdir)/icons/hicolor/24x24/apps/
 dist_icon_DATA = corebird.png

--- a/assets/32x32/Makefile.am
+++ b/assets/32x32/Makefile.am
@@ -1,2 +1,2 @@
-icondir = $(prefix)/share/icons/hicolor/32x32/apps/
+icondir = $(datarootdir)/icons/hicolor/32x32/apps/
 dist_icon_DATA = corebird.png

--- a/assets/48x48/Makefile.am
+++ b/assets/48x48/Makefile.am
@@ -1,2 +1,2 @@
-icondir = $(prefix)/share/icons/hicolor/48x48/apps/
+icondir = $(datarootdir)/icons/hicolor/48x48/apps/
 dist_icon_DATA = corebird.png

--- a/assets/64x64/Makefile.am
+++ b/assets/64x64/Makefile.am
@@ -1,2 +1,2 @@
-icondir = $(prefix)/share/icons/hicolor/64x64/apps/
+icondir = $(datarootdir)/icons/hicolor/64x64/apps/
 dist_icon_DATA = corebird.png

--- a/assets/96x96/Makefile.am
+++ b/assets/96x96/Makefile.am
@@ -1,2 +1,2 @@
-icondir = $(prefix)/share/icons/hicolor/96x96/apps/
+icondir = $(datarootdir)/icons/hicolor/96x96/apps/
 dist_icon_DATA = corebird.png

--- a/assets/Makefile.am
+++ b/assets/Makefile.am
@@ -1,2 +1,2 @@
-iconprefix=$(prefix)/share/icons/hicolor/
+iconprefix=$(datarootdir)/icons/hicolor/
 SUBDIRS = 128x128 96x96 64x64 48x48 32x32 24x24 16x16

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,10 +1,10 @@
 
-desktopdir = $(prefix)/share/applications
+desktopdir = $(datarootdir)/applications
 desktop_in_files = org.baedert.corebird.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
 
-appdatadir = $(prefix)/share/appdata
+appdatadir = $(datarootdir)/appdata
 appdata_in_files = org.baedert.corebird.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 @INTLTOOL_XML_RULE@

--- a/sql/accounts/Makefile.am
+++ b/sql/accounts/Makefile.am
@@ -1,2 +1,2 @@
-accountsdir = $(prefix)/share/corebird/sql/accounts
+accountsdir = $(datarootdir)/corebird/sql/accounts
 dist_accounts_DATA = Create.1.sql Create.2.sql

--- a/sql/init/Makefile.am
+++ b/sql/init/Makefile.am
@@ -1,2 +1,2 @@
-initdir = $(prefix)/share/corebird/sql/init
+initdir = $(datarootdir)/corebird/sql/init
 dist_init_DATA = Create.1.sql


### PR DESCRIPTION
The current situation leads to a broken installation if PREFIX is anything other than /usr or /usr/local.
If datarootdir is unset during configure, it still defaults to prefix/share.