### PR TITLE
Change the star icon to a heart icon.

### DIFF
--- a/src/FavoritesTimeline.vala
+++ b/src/FavoritesTimeline.vala
@@ -94,6 +94,6 @@ class FavoritesTimeline : IMessageReceiver, DefaultTimeline {
   }
 
   public override void create_radio_button (Gtk.RadioButton? group) {
-    radio_button = new BadgeRadioButton(group, "starred-symbolic", _("Favorites"));
+    radio_button = new BadgeRadioButton(group, "emblem-favorite-symbolic", _("Favorites"));
   }
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -169,7 +169,7 @@
 
 .favorite-button:hover,
 .favorite-button:checked {
-  color: shade(yellow, 0.9);
+  color: shade(red, 0.9);
 }
 
 /* Don't target :hover:active here */

--- a/ui/tweet-info-page.ui
+++ b/ui/tweet-info-page.ui
@@ -303,7 +303,7 @@
                   <object class="GtkImage" id="image2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="icon_name">starred-symbolic</property>
+                    <property name="icon_name">emblem-favorite-symbolic</property>
                     <property name="icon_size">1</property>
                   </object>
                 </child>

--- a/ui/tweet-list-entry.ui
+++ b/ui/tweet-list-entry.ui
@@ -73,7 +73,7 @@
                   <object class="GtkImage">
                     <property name="visible">true</property>
                     <property name="pixel_size">16</property>
-                    <property name="icon_name">starred-symbolic</property>
+                    <property name="icon_name">emblem-favorite-symbolic</property>
                   </object>
                 </child>
               </object>
@@ -200,7 +200,7 @@
                 <property name="valign">center</property>
                 <property name="margin_end">6</property>
                 <property name="pixel_size">12</property>
-                <property name="icon_name">starred-symbolic</property>
+                <property name="icon_name">emblem-favorite-symbolic</property>
                 <property name="no_show_all">true</property>
                 <style>
                   <class name="dim-label" />


### PR DESCRIPTION
It **only** replaces the star icon used for favorites/likes by a heart.
It doesn't change anything else behind that (label "Favorites", translation ID in the code or in the translations, etc.).

I could extend the PR using the Twitter website to fully replace the "Favorite" Twitter feature by their new "Like" labels, even for translations (using their website) but this PR has been submitted as is if someone wants hearts instead of stars.