### PR TITLE
Fix bug #473 by taking a shorter and more direct route

### DIFF
--- a/src/widgets/CompletionTextView.vala
+++ b/src/widgets/CompletionTextView.vala
@@ -38,11 +38,7 @@ class CompletionTextView : Gtk.TextView {
     this.focus_out_event.connect (completion_window_focus_out_cb);
 
     /* Your theme uses a wildcard for :link, right? */
-    var style_context = this.get_style_context ();
-    Gtk.StateFlags prev_state = style_context.get_state ();
-    style_context.set_state (Gtk.StateFlags.LINK);
-    Gdk.RGBA link_color = style_context.get_color (style_context.get_state ());
-    style_context.set_state (prev_state);
+    Gdk.RGBA link_color = this.get_style_context ().get_color (Gtk.StateFlags.LINK);
 
     if (link_color.red ==   1.0 &&
         link_color.green == 1.0 &&


### PR DESCRIPTION
I don't know why there's a difference, but if you just get the style context and ask it for the LINK state colour then it works.