### PR TITLE
Try to fix #457 by only removing Twitter image URLs

### DIFF
--- a/src/InlineMediaDownloader.vala
+++ b/src/InlineMediaDownloader.vala
@@ -41,7 +41,17 @@ bool is_media_candidate (string url) {
   ;
 }
 
+bool is_media_link_removal_candidate (string url) {
+  if (Settings.max_media_size () < 0.001)
+    return false;
 
+  return
+#if VIDEO
+         url.has_suffix ("/photo/1") ||
+         url.has_prefix ("https://video.twimg.com/ext_tw_video/") ||
+#endif
+         url.has_prefix ("http://pbs.twimg.com/media/");
+}
 
 public class InlineMediaDownloader : GLib.Object {
   private static InlineMediaDownloader instance;

--- a/src/util/TextTransform.vala
+++ b/src/util/TextTransform.vala
@@ -42,7 +42,7 @@ namespace TextTransform {
                              string  display_text,
                              uint    media_count)
   {
-    return (is_media_candidate (url ?? display_text) &&
+    return (is_media_link_removal_candidate (url ?? display_text) &&
             media_count == 1) || display_text.has_prefix ("pic.twitter.com/");
   }
 


### PR DESCRIPTION
This is basically what Twitter does with its "cards" (Flic.kr links
remain but the card shows the image).

The only issue so far is if someone uses IFTTT or similar to auto-
post Flickr photos. IFTTT puts the Flickr URL in *and* uploads the
photo to Twitter, which results in us seeing it twice.