### PR TITLE
Fix tweet length calculation when quoting

### DIFF
--- a/src/window/ComposeTweetWindow.vala
+++ b/src/window/ComposeTweetWindow.vala
@@ -147,7 +147,7 @@ class ComposeTweetWindow : Gtk.ApplicationWindow {
     int length = TweetUtils.calc_tweet_length (text, media_count);
 
     if (this.mode == Mode.QUOTE)
-      length += Twitter.short_url_length_https;
+      length += 1 + Twitter.short_url_length_https; //Quoting will add a space and then the tweet's URL
 
 
     length_label.label = (Tweet.MAX_LENGTH - length).to_string ();


### PR DESCRIPTION
When quoting a tweet, the URL is appended AFTER the user submits (https://github.com/baedert/corebird/blob/master/src/async/ComposeJob.vala#L128). The submission also puts a space before the URL, but the length calculation forgets about the space. This can result in quote tweets that say "0 characters remaining" actually being rejected and triggering bug #466.

Adding an extra 1 to length makes the calculation correct when quoting.