### PR TITLE
Fix miscount with trailing space

### DIFF
--- a/src/util/TweetUtils.vala
+++ b/src/util/TweetUtils.vala
@@ -194,7 +194,7 @@ namespace TweetUtils {
 
     for (int next = 0, c_n = 0; text.get_next_char (ref next, out c); c_n ++) {
       if (c == ' ' || c == '\n' || c_n == n_chars - 1) {
-        if (c_n == n_chars - 1)
+        if (c_n == n_chars - 1 && c != ' ' && c != '\n')
           cur = next;
 
         string word = text.substring (last_word_start,

--- a/tests/tweet_length.vala
+++ b/tests/tweet_length.vala
@@ -70,6 +70,13 @@ void whitespace () {
   assert (l == 11);
 }
 
+void trailing_space () {
+  string text = "Foo Bar ";
+  int l = TweetUtils.calc_tweet_length (text);
+  message ("Length: %d", l);
+  assert (l == 8);
+}
+
 void utf8 () {
   string text = "€¤²˛×     ××¹áœ http://¤³¤€.com"; // 5 + 5 + 5 + 1 + 22
   message (text);
@@ -107,6 +114,7 @@ int main (string[] args) {
   GLib.Test.add_func ("/tweet-length/real-text1", real_text1);
   GLib.Test.add_func ("/tweet-length/newline-link", newline_link);
   GLib.Test.add_func ("/tweet-length/whitespace", whitespace);
+  GLib.Test.add_func ("/tweet-length/trailing_space", trailing_space);
   GLib.Test.add_func ("/tweet-length/utf8", utf8);
   //GLib.Test.add_func ("/tweet-length/punctuation-url", punctuation_url); XXX Fails.
   GLib.Test.add_func ("/tweet-length/unicode1", unicode1);


### PR DESCRIPTION
Fix #504 - code assumed that we'd either be checking word length because we'd found whitespace to start a word, or we'd reached the end of the string. It didn't account for reaching the end of the string and finding whitespace in the same iteration of the loop.