### PR TITLE
Allow DM text selection

### DIFF
--- a/ui/dm-list-entry.ui
+++ b/ui/dm-list-entry.ui
@@ -102,6 +102,7 @@
             <property name="wrap_mode">word-char</property>
             <property name="use_markup">True</property>
             <property name="track_visited_links">false</property>
+            <property name="selectable">True</property>
           </object>
           <packing>
             <property name="left_attach">1</property>


### PR DESCRIPTION
This allows text selection for a DM directly. Related to #98.

![dm-text-selection](https://cloud.githubusercontent.com/assets/601685/12868919/b3ef0f96-ccdf-11e5-884a-0ff8379534ba.png)
