### PR TITLE
Render media in max 4:3 proportions box

### DIFF
--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -99,8 +99,10 @@ private class MediaButton : Gtk.Widget {
       return;
     }
 
-    int maxHeight = (int) Math.floor((this.get_allocated_width () / 4.0) * 3);
-    height = int.min(this._media.height, maxHeight);
+    int maxHeightAllocated = (int) Math.floor((this.get_allocated_width () / 4.0) * 3);
+    int maxHeightFromWidth = (int) Math.floor((this._media.width / 4.0) * 3);
+    height = int.min(this._media.height, maxHeightAllocated);
+    height = int.min (height, maxHeightFromWidth);
 
     if (this._media.width > this.get_allocated_width ()) {
       width = this.get_allocated_width ();
@@ -202,13 +204,12 @@ private class MediaButton : Gtk.Widget {
     }
 
     int maxHeight = (int) Math.floor((int.min(media_width, width) / 4.0) * 3);
-    int height = int.min(media_height, maxHeight);
+    double width_scale = width / (double) media_width;
+    int scaled_height = (int) Math.floor(media_height * width_scale);
+    int height = int.min(int.min(media_height, maxHeight), scaled_height);
     minimum = natural = height;
     if (this._media != null) {
-      //FIXME: The calls are height_for_width, width_for_height, height_for_width
-      //We need to make sure they're consistent, as currently width_for_height returns
-      //too wide a width!
-      stderr.printf("get_preferred_height_for_width(%d) for %s (%d x %d): %d\n", width, this._media.url, this._media.width, this._media.height, height);
+      stderr.printf("get_preferred_height_for_width(%d) for %s (%d x %d): %d (max %d)\n", width, this._media.url, this._media.width, this._media.height, height, maxHeight);
     }
   }
 
@@ -228,21 +229,21 @@ private class MediaButton : Gtk.Widget {
 
     //double height_ratio = (double)height / (double)media_height;
     //int width = int.min (media_width, (int)(media_width * height_ratio));
-    int maxWidth = (height / 3) * 4;
+    int maxWidth = (int) Math.floor((height / 3.0) * 4);
     int width = int.min(media_height, maxWidth);
     minimum = natural = width;
     if (this._media != null) {
-      stderr.printf("get_preferred_width_for_height(%d) for %s (%d x %d): %d\n", height, this._media.url, this._media.width, this._media.height, width);
+      stderr.printf("get_preferred_width_for_height(%d) for %s (%d x %d): %d (max %d)\n", height, this._media.url, this._media.width, this._media.height, width, maxWidth);
     }
   }
 
   public override void get_preferred_height (out int minimum,
                                              out int natural) {
     int media_height;
-    if (this._media == null || this._media.width == -1) {
+    if (this._media == null || this._media.height == -1) {
       media_height = 1;
     } else {
-      media_height = this._media.width;
+      media_height = this._media.height;
     }
 
     minimum = int.min (media_height, MIN_HEIGHT);

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -99,15 +99,19 @@ private class MediaButton : Gtk.Widget {
       return;
     }
 
-    width  = this.get_allocated_width ();
-    height = this.get_allocated_height ();
-    double scale_x = (double)width / this._media.width;
-    double scale_y = (double)height / this._media.height;
-
-    scale = double.min (double.min (scale_x, scale_y), 1.0);
-
-    width  = (int)(this._media.width  * scale);
-    height = (int)(this._media.height * scale);
+    if (this._media.width > this.get_allocated_width ()) {
+      width = this.get_allocated_width ();
+      int maxHeight = (int) Math.floor((width / 4.0) * 3);
+      height = int.min(this._media.height, maxHeight);
+      scale = this.get_allocated_width () / (double) this._media.width;
+      stderr.printf("Scale %s: %d x %d => %d x %d (%f)\n", this._media.url,this._media.width,this._media.height,width,height, scale);
+    } else {
+      width = this._media.width;
+      int maxHeight = (int)Math.floor((this._media.width / 4.0) * 3);
+      height = int.min(this._media.height, maxHeight);
+      scale = 1;
+      stderr.printf("No scale %s: %d x %d => %d x %d (%f)\n", this._media.url,this._media.width,this._media.height,width,height, scale);
+    }
   }
 
   public override bool draw (Cairo.Context ct) {

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -103,7 +103,7 @@ private class MediaButton : Gtk.Widget {
     scale = this.get_allocated_width () / (double) this._media.width;
 
     if (scale > 1) {
-      height = int.min (this._media.height, (int) Math.floor((this.get_allocated_width () / 4.0) * 3));
+      height = int.min (this._media.height, (int) Math.floor ((this.get_allocated_width () / 4.0) * 3));
       scale = 1;
     } else {
       height = (int) Math.floor (double.min (this._media.height * scale, (this._media.width * scale / 4.0) * 3));
@@ -128,7 +128,8 @@ private class MediaButton : Gtk.Widget {
       int draw_x = (widget_width / 2) - (draw_width / 2);
 
       ct.scale (scale, scale);
-      ct.set_source_surface (media.surface, draw_x / scale, -(((media.height * scale) - draw_height) / 2) / scale);
+      double draw_y = -(((media.height * scale) - draw_height) / 2);
+      ct.set_source_surface (media.surface, draw_x / scale, draw_y / scale);
       ct.fill ();
       ct.restore ();
 
@@ -203,7 +204,7 @@ private class MediaButton : Gtk.Widget {
     int height = 0;
 
     if (scale > 1) {
-      height = int.min (media_height, (int) Math.floor((width / 4.0) * 3));
+      height = int.min (media_height, (int) Math.floor ((width / 4.0) * 3));
     } else {
       height = (int) Math.floor (double.min (media_height * scale, (media_width * scale / 4.0) * 3));
     }
@@ -225,9 +226,10 @@ private class MediaButton : Gtk.Widget {
       media_height = this._media.height;
     }
 
-    int maxWidth = (int) Math.floor((height / 3.0) * 4);
-    int width = int.min(media_width, maxWidth);
-    minimum = natural = width;
+    int max_width = (int) Math.floor ((height / 3.0) * 4);
+    int width = int.min (media_width, max_width);
+    minimum = int.min (media_width, MIN_WIDTH);
+    natural = width;
   }
 
   public override void get_preferred_height (out int minimum,

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -99,18 +99,17 @@ private class MediaButton : Gtk.Widget {
       return;
     }
 
+    int maxHeight = (int) Math.floor((this.get_allocated_width () / 4.0) * 3);
+    height = int.min(this._media.height, maxHeight);
+
     if (this._media.width > this.get_allocated_width ()) {
       width = this.get_allocated_width ();
-      int maxHeight = (int) Math.floor((width / 4.0) * 3);
-      height = int.min(this._media.height, maxHeight);
-      scale = this.get_allocated_width () / (double) this._media.width;
-      stderr.printf("Scale %s: %d x %d => %d x %d (%f)\n", this._media.url,this._media.width,this._media.height,width,height, scale);
+      scale = width / (double) this._media.width;
+      stderr.printf("Scale %s: %d x %d => %d x %d (%f) in %d x %d\n", this._media.url,this._media.width,this._media.height,width,height, scale, this.get_allocated_width (), this.get_allocated_height ());
     } else {
       width = this._media.width;
-      int maxHeight = (int)Math.floor((this._media.width / 4.0) * 3);
-      height = int.min(this._media.height, maxHeight);
       scale = 1;
-      stderr.printf("No scale %s: %d x %d => %d x %d (%f)\n", this._media.url,this._media.width,this._media.height,width,height, scale);
+      stderr.printf("No scale %s: %d x %d => %d x %d (%f) in %d x %d\n", this._media.url,this._media.width,this._media.height,width,height, scale, this.get_allocated_width (), this.get_allocated_height ());
     }
   }
 
@@ -193,7 +192,7 @@ private class MediaButton : Gtk.Widget {
                                                        out int natural) {
     int media_width;
     int media_height;
-
+    
     if (this._media == null || this._media.width == -1 || this._media.height == -1) {
       media_width = MIN_WIDTH;
       media_height = MAX_HEIGHT;
@@ -202,9 +201,15 @@ private class MediaButton : Gtk.Widget {
       media_height = this._media.height;
     }
 
-    double width_ratio = (double)width / (double) media_width;
-    int height = int.min (media_height, (int)(media_height * width_ratio));
+    int maxHeight = (int) Math.floor((int.min(media_width, width) / 4.0) * 3);
+    int height = int.min(media_height, maxHeight);
     minimum = natural = height;
+    if (this._media != null) {
+      //FIXME: The calls are height_for_width, width_for_height, height_for_width
+      //We need to make sure they're consistent, as currently width_for_height returns
+      //too wide a width!
+      stderr.printf("get_preferred_height_for_width(%d) for %s (%d x %d): %d\n", width, this._media.url, this._media.width, this._media.height, height);
+    }
   }
 
   public override void get_preferred_width_for_height (int height,
@@ -221,9 +226,14 @@ private class MediaButton : Gtk.Widget {
       media_height = this._media.height;
     }
 
-    double height_ratio = (double)height / (double)media_height;
-    int width = int.min (media_width, (int)(media_width * height_ratio));
+    //double height_ratio = (double)height / (double)media_height;
+    //int width = int.min (media_width, (int)(media_width * height_ratio));
+    int maxWidth = (height / 3) * 4;
+    int width = int.min(media_height, maxWidth);
     minimum = natural = width;
+    if (this._media != null) {
+      stderr.printf("get_preferred_width_for_height(%d) for %s (%d x %d): %d\n", height, this._media.url, this._media.width, this._media.height, width);
+    }
   }
 
   public override void get_preferred_height (out int minimum,
@@ -237,6 +247,7 @@ private class MediaButton : Gtk.Widget {
 
     minimum = int.min (media_height, MIN_HEIGHT);
     natural = media_height;
+    stderr.printf("get_preferred_height() for %s (%d x %d): %d or %d\n", this._media.url, this._media.width, this._media.height, minimum, natural);
   }
 
   public override void get_preferred_width (out int minimum,
@@ -250,6 +261,7 @@ private class MediaButton : Gtk.Widget {
 
     minimum = int.min (media_width, MIN_WIDTH);
     natural = media_width;
+    stderr.printf("get_preferred_width() for %s (%d x %d): %d or %d\n", this._media.url, this._media.width, this._media.height, minimum, natural);
   }
 
   public override void realize () {


### PR DESCRIPTION
My proposal to balance "I don't want tall images" with "I like media and run Corebird really wide" in Bug #465.

These changes make the visible part of the media render at max 4:3 proportions (chosen because they're old monitor proportions, fairly square and hence don't make you go "huh? what size/shape is that?", and still quite common for images based on what I saw in my timeline).

If the image is too wide then Corebird will scale the image (as it does now).

If the image is too tall then Corebird will show the middle of the image.

If the widget's bounding box is wider than the image then Corebird uses 4:3 proportions on the bounding box to calculate the max height, which will allow portrait images to show more height. (But if the image is landscape then the box won't grow too tall)