### PR TITLE
Fix logging of URL that failed to download

### DIFF
--- a/src/MediaDownloader.c
+++ b/src/MediaDownloader.c
@@ -319,7 +319,7 @@ cb_media_downloader_load_threaded (CbMediaDownloader *downloader,
   if (msg->status_code != SOUP_STATUS_OK)
     {
       g_debug ("Request on '%s' returned status '%s'",
-               media->thumb_url,
+               media->thumb_url ? media->thumb_url : media->url,
                soup_status_get_phrase (msg->status_code));
 
       mark_invalid (media);


### PR DESCRIPTION
media->thumb_url isn't set for all images (only those requiring web page download first) so make sure we don't get nulls in logs when we want to know what failed by using the same ternary as was used in the Soup message creation.