### PR TITLE
Tweet JSON includes HTTPS URLs for media. Use them where they exist.

### DIFF
--- a/src/Types.c
+++ b/src/Types.c
@@ -475,7 +475,9 @@ cb_mini_tweet_parse_entities (CbMiniTweet *t,
 
           if (strcmp (media_type, "photo") == 0)
             {
-              const char *url = json_object_get_string_member (media_obj, "media_url");
+              const char *url = json_object_has_member (media_obj, "media_url_https") ?
+                json_object_get_string_member (media_obj, "media_url_https") :
+                json_object_get_string_member (media_obj, "media_url");
               gboolean dup = FALSE;
 
               /* Remove duplicates */
@@ -546,7 +548,9 @@ cb_mini_tweet_parse_entities (CbMiniTweet *t,
               if (variant != NULL)
                 {
                   int n_media = t->n_medias;
-                  const char *thumb_url = json_object_get_string_member (media_obj, "media_url");
+                  const char *thumb_url = json_object_has_member (media_obj, "media_url_https") ?
+                    json_object_get_string_member (media_obj, "media_url_https") :
+                    json_object_get_string_member (media_obj, "media_url");
                   /* Some tweets have both a video and a thumbnail for that video attached. The tweet json
                    * will list the image first. The url of the image and the thumb_url of the video will match
                    */


### PR DESCRIPTION
I discovered while investigating issue #603. Seems sensible to use HTTPS whenever it is available.
