### PR TITLE
Use "attachment_url" to fix tweet quoting

### DIFF
--- a/src/async/ComposeJob.vala
+++ b/src/async/ComposeJob.vala
@@ -123,9 +123,9 @@ class ComposeJob : GLib.Object {
       call.add_param ("in_reply_to_status_id", this.reply_id.to_string ());
     } else if (this.quoted_tweet != null) {
       Cb.MiniTweet mt = quoted_tweet.retweeted_tweet ?? quoted_tweet.source_tweet;
-
-      this.text += " https://twitter.com/%s/status/%s".printf (mt.author.screen_name,
-                                                               mt.id.to_string ());
+      var quoted_url = "https://twitter.com/%s/status/%s".printf (mt.author.screen_name,
+                                                                  mt.id.to_string ());
+      call.add_param ("attachment_url", quoted_url);
     }
 
     call.add_param ("status", this.text);


### PR DESCRIPTION
Previous behaviour was that counter didn't count URL, but it was
appended during send, so you got an error about tweet length at
send time.

If we don't do this, quote tweets with 120+ chars of text fail because the added URL takes it over 140 chars.