### PR TITLE
DMPage: avoid window resizing on typing.

### DIFF
--- a/ui/dm-page.ui
+++ b/ui/dm-page.ui
@@ -30,6 +30,7 @@
             <property name="margin">6</property>
             <child>
               <object class="GtkScrolledWindow">
+                <property name="visible">1</property>
                 <child>
                   <object class="CompletionTextView" id="text_view">
                     <property name="visible">True</property>

--- a/ui/dm-page.ui
+++ b/ui/dm-page.ui
@@ -29,11 +29,15 @@
             <property name="visible">1</property>
             <property name="margin">6</property>
             <child>
-              <object class="CompletionTextView" id="text_view">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="wrap-mode">word-char</property>
-                <signal name="key_press_event" handler="text_view_key_press_cb"/>
+              <object class="GtkScrolledWindow">
+                <child>
+                  <object class="CompletionTextView" id="text_view">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="wrap-mode">word-char</property>
+                    <signal name="key_press_event" handler="text_view_key_press_cb"/>
+                  </object>
+                </child>
               </object>
             </child>
           </object>


### PR DESCRIPTION
Puts the CompletionTextView in a GtkScrolledWindow to avoid the window from resizing to the size of the content of the DM. 

Before this commit, the window is resized to the size of the typed text:

![The windows has been resized to the size of the typed text](https://cloud.githubusercontent.com/assets/1798689/19221501/f1af90cc-8e44-11e6-869e-64b12d3df13a.png)

After the commit, the window is not resized:

![The window is not resized](https://cloud.githubusercontent.com/assets/1798689/19221504/005cdcc4-8e45-11e6-94b3-684e1a429ba9.png)

Note that the edit field has now 3 rows (against one before this commit) but `max-content-height` property is available since `gtk 3.22` only (released in sept. 2016 and not available everywhere) :
 
https://developer.gnome.org/gtk3/stable/GtkScrolledWindow.html#GtkScrolledWindow--max-content-height 

But as direct messages are not limited in size anymore on Twitter, I don't see this as a regression. Let me know if you wan't me to limit the size of the height to one row.

Again, thanks for your great app!