### PR TITLE
Fix Bug636 sigsegv after quoting

### DIFF
--- a/src/Types.c
+++ b/src/Types.c
@@ -158,7 +158,8 @@ cb_mini_tweet_copy (CbMiniTweet *t1, CbMiniTweet *t2)
 
   t2->n_entities = t1->n_entities;
   t2->entities = g_new0 (CbTextEntity, t2->n_entities);
-  memcpy  (&t2->entities, &t1->entities, sizeof (CbTextEntity) * t2->n_entities);
+  for (i = 0; i < t2->n_entities; i ++)
+    cb_text_entity_copy (&t1->entities[i], &t2->entities[i]);
 
   t2->n_medias = t1->n_medias;
   t2->medias = g_new0 (CbMedia*, t2->n_medias);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,6 +34,7 @@ TESTS = \
 	texttransform \
 	avatardownload \
 	friends \
+	Types \
 	highlighting
 
 check_PROGRAMS = $(TESTS)
@@ -50,6 +51,7 @@ tests_VALASOURCES = \
 	texttransform.vala \
 	avatardownload.vala \
 	friends.vala \
+	Types.vala \
 	highlighting.vala
 
 $(tests_VALASOURCES:.vala=.c): tests_vala.stamp
@@ -105,6 +107,9 @@ texttransform_LDADD = $(top_builddir)/src/libcorebird.la
 
 nodist_avatardownload_SOURCES = avatardownload.c corebird-resources.c
 avatardownload_LDADD = $(top_builddir)/src/libcorebird.la
+
+nodist_Types_SOURCES = Types.c
+Types_LDADD = $(top_builddir)/src/libcorebird.la
 
 CLEANFILES = \
 	tests_vala.stamp \

--- a/tests/Types.vala
+++ b/tests/Types.vala
@@ -1,0 +1,30 @@
+// Bug 636 - copying tweets causes SIGSEGV later on original tweet
+void copy_free_minitweet () {
+  const string display_text = "#DisplayText";
+  Cb.MiniTweet t1 = Cb.MiniTweet ();  
+  t1.id = 100;
+  t1.author = Cb.UserIdentity ();
+  t1.author.id = 100;
+  t1.entities = new Cb.TextEntity[1];
+  t1.entities[0] = new Cb.TextEntity();
+  t1.entities[0].display_text = display_text;
+  t1.entities[0].tooltip_text = "";
+  t1.entities[0].target = "";
+
+  if (true) {
+    // Put t2 in a block to try and trigger a free() at the end
+    Cb.MiniTweet t2 = t1;
+    // Simple assertion so that the block doesn't get optimised away
+    assert (t1.entities[0].display_text == t2.entities[0].display_text);
+  }
+
+  // If everything is okay, entity.display_text should remain
+  // If we have the bug, freeing t2 freed the display_text on t1
+  assert (t1.entities[0].display_text == display_text);
+}
+
+int main (string[] args) {
+  GLib.Test.init (ref args);
+  GLib.Test.add_func ("/types/copy_and_free_minitweet", copy_free_minitweet);
+  return GLib.Test.run ();
+}


### PR DESCRIPTION
Unit test and fix for SIGSEGV issue after quoting a tweet (bug #636). I'm not sure if it is perfect C code, but it makes the test pass and seems to stop Corebird crashing after I applied it.
