### PR TITLE
Fixed icon name

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -74,7 +74,7 @@ msgstr ""
 
 #: data/org.baedert.corebird.desktop.in:11
 msgid "corebird"
-msgstr "Corebird"
+msgstr "corebird"
 
 #: src/DefaultTimeline.vala:359
 msgid "Could not load tweets"


### PR DESCRIPTION
In line 77 is the name of the icon. The translation „Corebird“ with a capital C prevents the icon from showing.