### PR TITLE
Recalculate min_id on removing tweets

### DIFF
--- a/src/CbTweetModel.c
+++ b/src/CbTweetModel.c
@@ -686,7 +686,7 @@ cb_tweet_model_remove_last_n_visible (CbTweetModel *self,
                             size_before - amount,
                             amount);
   emit_items_changed (self, size_before - amount, amount, 0);
-  /*update_min_max_id (self);*/
+  update_min_max_id (self, self->min_id);
 }
 
 void


### PR DESCRIPTION
As per bug #685, the min_id in the model gets updated when adding tweets but never when removing. The commented out call to update_min_max_id seems to be integral to this working properly.

I can't see a reason it was commented out, and Corebird doesn't behave correctly for me unless I uncomment it.