### PR TITLE
Recalculate min_id on removing tweets

### DIFF
--- a/src/CbTweetModel.c
+++ b/src/CbTweetModel.c
@@ -685,8 +685,8 @@ cb_tweet_model_remove_last_n_visible (CbTweetModel *self,
   g_ptr_array_remove_range (self->tweets,
                             size_before - amount,
                             amount);
+  update_min_max_id (self, self->min_id);
   emit_items_changed (self, size_before - amount, amount, 0);
-  /*update_min_max_id (self);*/
 }
 
 void


### PR DESCRIPTION
As per bug #685, the min_id in the model gets updated when adding tweets but never when removing. The commented out call to update_min_max_id seems to be integral to this working properly.
This needs to be done *before* the emit_items_changed in case anything that gets notified needs to know the new min_id.