### PR TITLE
Import libtweetlength changes to count "weighted" characters

### DIFF
--- a/src/libtl/libtweetlength.h
+++ b/src/libtl/libtweetlength.h
@@ -27,6 +27,7 @@ struct _TlEntity {
 
   gsize start_character_index;
   gsize length_in_characters;
+  gsize length_in_weighted_characters;
 };
 typedef struct _TlEntity TlEntity;
 
@@ -40,6 +41,9 @@ typedef enum {
 
 gsize      tl_count_characters            (const char *input);
 gsize      tl_count_characters_n          (const char *input,
+                                           gsize       length_in_bytes);
+gsize      tl_count_weighted_characters   (const char *input);
+gsize      tl_count_weighted_characters_n (const char *input,
                                            gsize       length_in_bytes);
 TlEntity * tl_extract_entities            (const char *input,
                                            gsize      *out_n_entities,

--- a/src/window/ComposeTweetWindow.vala
+++ b/src/window/ComposeTweetWindow.vala
@@ -210,7 +210,7 @@ class ComposeTweetWindow : Gtk.ApplicationWindow {
     tweet_text.buffer.get_bounds (out start, out end);
     string text = tweet_text.buffer.get_text (start, end, true);
 
-    int length = (int)Tl.count_characters (text);
+    int length = (int)Tl.count_weighted_characters (text);
     length_label.label = (Cb.Tweet.MAX_LENGTH - length).to_string ();
 
     if (length > 0 && length <= Cb.Tweet.MAX_LENGTH ||

--- a/vapi/libtl.vapi
+++ b/vapi/libtl.vapi
@@ -15,11 +15,15 @@ namespace Tl {
     size_t start_character_index;
     size_t length_in_characters;
     size_t length_in_bytes;
+    size_t length_in_weighted_characters;
   }
 
 
   [CCode (cprefix = "tl_", lower_case_cprefix = "tl_", cheader_filename = "libtl/libtweetlength.h")]
   size_t count_characters (string input);
+
+  [CCode (cprefix = "tl_", lower_case_cprefix = "tl_", cheader_filename = "libtl/libtweetlength.h")]
+  size_t count_weighted_characters (string input);
 
   [CCode (cprefix = "tl_", lower_case_cprefix = "tl_", cheader_filename = "libtl/libtweetlength.h",
           array_length_pos = 1)]


### PR DESCRIPTION
This imports the libtweetlength changes into Master (which I'm still using, because I can't get "next2" to compile yet, and I don't know quite how stable it is) but it should work fine with future branches as well.